### PR TITLE
Adds mechanism for updating styles

### DIFF
--- a/src/ResponsiveGauge.js
+++ b/src/ResponsiveGauge.js
@@ -677,13 +677,27 @@ var ResponsiveGaugeFactory = (function(_d3, _numbro) {
 		function update(newValue, newConfiguration) {
 			config.data.value = (newValue === undefined ? 0 : newValue);
 
-			// update pointer position
-			renderPointer();
+			if(!newConfiguration) {
 
-			// updates value label
-			if (config.value.show) {
-				valueLabel.text(config.value.formatter(config.data.value));
-			}
+			    // update pointer position
+			    renderPointer();
+
+			    // updates value label
+			    if (config.value.show) {
+			       valueLabel.text(config.value.formatter(config.data.value));
+			    }
+			 } else {
+			    // we remove the old SVG element and re-init from scratch
+			    // decomposing the 'render' function does not solve anything
+			    // since some old elements remain displayed
+			    var containerElement = document.getElementById(container.slice(1));
+			    var gaugeSVG = containerElement.getElementsByTagName("svg")[0];
+			    containerElement.removeChild(gaugeSVG);
+
+			    render(newConfiguration);
+			    update(config.data.value);
+			 }
+						
 		}
 
 		render(configuration);


### PR DESCRIPTION
This adds a (primitive) mechanism for updating the styles of a gauge together with the value (as the documentation states).

This removes the present SVG graphic and then just re-runs the initial configuation.

Not running "rencerContainer" as part of the "render" function resulted in some updates to the existing SVG, but old elements remained.

This does what I need it to do well enough, but is probably wasteful.